### PR TITLE
Remove useless require rubygems

### DIFF
--- a/lib/lookup_http.rb
+++ b/lib/lookup_http.rb
@@ -53,7 +53,6 @@ class LookupHttp
   # and return its structured representation.  Currently we support YAML and JSON
   #
   def parse_json(answer)
-    require 'rubygems'
     require 'json'
     JSON.parse(answer)
   end


### PR DESCRIPTION
The require rubygems was not neccessary and should be removed to build proper deb packages
