### PR TITLE
Fix SSL config bugs

### DIFF
--- a/lib/lookup_http.rb
+++ b/lib/lookup_http.rb
@@ -26,9 +26,9 @@ class LookupHttp
         store = OpenSSL::X509::Store.new
         store.add_cert(OpenSSL::X509::Certificate.new(File.read(@config[:ssl_ca_cert])))
         @http.cert_store = store
-
-        @http.key = OpenSSL::PKey::RSA.new(File.read(@config[:ssl_key]))
-        @http.cert = OpenSSL::X509::Certificate.new(File.read(@config[:ssl_cert]))
+        @http.key     = OpenSSL::PKey::RSA.new(File.read(@config[:ssl_key]))
+        @http.cert    = OpenSSL::X509::Certificate.new(File.read(@config[:ssl_cert]))
+        @http.ca_file = @config[:ssl_ca_cert]
       end
     else
       @http.use_ssl = false

--- a/lib/lookup_http.rb
+++ b/lib/lookup_http.rb
@@ -21,15 +21,15 @@ class LookupHttp
       else
         @http.verify_mode = OpenSSL::SSL::VERIFY_PEER
       end
-
+      
       if @config[:ssl_cert]
-        store = OpenSSL::X509::Store.new
-        store.add_cert(OpenSSL::X509::Certificate.new(File.read(@config[:ssl_ca_cert])))
-        @http.cert_store = store
-        @http.key     = OpenSSL::PKey::RSA.new(File.read(@config[:ssl_key]))
-        @http.cert    = OpenSSL::X509::Certificate.new(File.read(@config[:ssl_cert]))
+        @http.cert = OpenSSL::X509::Certificate.new(File.read(@config[:ssl_cert]))
+        @http.key = OpenSSL::PKey::RSA.new(File.read(@config[:ssl_key]))
+      end 
+      
+      if @config[:ssl_ca_cert]
         @http.ca_file = @config[:ssl_ca_cert]
-      end
+      end       
     else
       @http.use_ssl = false
     end

--- a/lib/lookup_http.rb
+++ b/lib/lookup_http.rb
@@ -27,8 +27,8 @@ class LookupHttp
         store.add_cert(OpenSSL::X509::Certificate.new(File.read(@config[:ssl_ca_cert])))
         @http.cert_store = store
 
-        @http.key = OpenSSL::PKey::RSA.new(File.read(@config[:ssl_cert]))
-        @http.cert = OpenSSL::X509::Certificate.new(File.read(@config[:ssl_key]))
+        @http.key = OpenSSL::PKey::RSA.new(File.read(@config[:ssl_key]))
+        @http.cert = OpenSSL::X509::Certificate.new(File.read(@config[:ssl_cert]))
       end
     else
       @http.use_ssl = false


### PR DESCRIPTION
This patch fixes some problems with the SSL-related `@config` logic:

* The `:ssl_key` and `:ssl_cert` options were swapped in `@http`.
* `OpenSSL::X509::Certificate.new` only read the first certificate in 
  its String. This caused problems in cases where `:ssl_verify` is true
  and the `:ssl_ca_cert` file contains multiple CA certificates.
* It was impossible to specify `:ssl_ca_cert` without also providing 
  `:ssl_cert` and `:ssl_key` (which aren't always needed).